### PR TITLE
fix(gemspec): remove implicit and useless active-support dependency.

### DIFF
--- a/smtp_url.gemspec
+++ b/smtp_url.gemspec
@@ -1,6 +1,6 @@
 # encoding: utf-8
 $:.push File.expand_path("../lib", __FILE__)
-require "smtp_url"
+require "smtp_url/version"
 
 Gem::Specification.new do |s|
   s.name        = "smtp_url"


### PR DESCRIPTION
In some specific cases, `bundle` may fail to install smtp_url when activesupport is not already in the LOAD_PATH (when activesupport is not already installed system-wide).

How to reproduce:

``` sh
$ git clone https://github.com/danielfarrell/smtp_url
$ mkdir test
$ cd test
$ echo -e "source 'https://rubygems.org'\ngem 'smtp_url', path: '../smtp_url'" | tee Gemfile
$ bundle install --path .bundle
There was a LoadError while loading smtp_url.gemspec: 
cannot load such file -- active_support/core_ext/object/try from
  /home/julien/smtp_url/smtp_url.gemspec:3:in `<main>'

Does it try to require a relative path? That's been removed in Ruby 1.9.
```

Fix: `require 'smtp_url/version'` in the gemspec instead of `require 'smtp_url'`
